### PR TITLE
Bootstrap build pipeline and tarball packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # output
 out
 dist
+workdir
 *.tgz
 
 # code coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "workbench.colorCustomizations": {
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#b495b7",
+    "statusBar.background": "#9e77a2",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#855d89",
+    "statusBarItem.remoteBackground": "#9e77a2",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#9e77a2",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#9e77a299",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#9e77a2"
+}

--- a/README.md
+++ b/README.md
@@ -26,5 +26,28 @@ the group, but the group should be built in order.
 - Group 4
   - tscircuit
 
-
 These packages have dependencies on one another, e.g. @tscircuit/runframe depends on @tscircuit/pcb-viewer, so @tscircuit/pcb-viewer needs to be built first. They are universally built with `bun run build`. Some dependencies will depend on later dependencies- this is OK. Where a later dependency is required, we just use the version in the package.json file.
+
+## Bootstrapped build pipeline
+
+This repository now contains a Bun-powered build orchestrator that will clone, build, link and package the bleeding release of tscircuit.
+
+- All repositories are cloned into `./workdir/<package>` and reused on subsequent runs.
+- Build artifacts and the generated tarball are written to `./dist`.
+- A manifest (`dist/build-manifest.json`) captures the commit for every dependency that was built.
+
+### Running the build locally
+
+```bash
+bun install
+bun run build
+```
+
+The build process fetches the latest commits from each dependency, runs their `bun run build` command and links them together before packaging `tscircuit` with `npm pack`. The resulting tarball will be renamed to `tscircuit-bleeding-<timestamp>.tgz` and placed in the `dist/` directory alongside the manifest.
+
+To override the workspace or output directories you can pass flags directly to the CLI:
+
+```bash
+# Use a custom workspace and output directory
+bun run src/index.ts build --workspace /tmp/bleeding-workdir --dist /tmp/bleeding-dist
+```

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/cosmos-export",
+      "!**/dist",
+      "!**/package.json",
+      "!workdir/**"
+    ]
+  },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "all",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "complexity": {
+        "noForEach": "error",
+        "useLiteralKeys": "off"
+      },
+      "a11y": {
+        "noAccessKey": "off",
+        "noAriaHiddenOnFocusable": "off",
+        "noAriaUnsupportedElements": "off",
+        "noAutofocus": "off",
+        "noDistractingElements": "off",
+        "noHeaderScope": "off",
+        "noInteractiveElementToNoninteractiveRole": "off",
+        "noLabelWithoutControl": "off",
+        "noNoninteractiveElementToInteractiveRole": "off",
+        "noNoninteractiveTabindex": "off",
+        "noPositiveTabindex": "off",
+        "noRedundantAlt": "off",
+        "noRedundantRoles": "off",
+        "noStaticElementInteractions": "off",
+        "noSvgWithoutTitle": "off",
+        "useAltText": "off",
+        "useAnchorContent": "off",
+        "useAriaActivedescendantWithTabindex": "off",
+        "useAriaPropsForRole": "off",
+        "useAriaPropsSupportedByRole": "off",
+        "useButtonType": "off",
+        "useFocusableInteractive": "off",
+        "useHeadingContent": "off",
+        "useHtmlLang": "off",
+        "useIframeTitle": "off",
+        "useKeyWithClickEvents": "off",
+        "useKeyWithMouseEvents": "off",
+        "useMediaCaption": "off",
+        "useSemanticElements": "off",
+        "useValidAnchor": "off",
+        "useValidAriaProps": "off",
+        "useValidAriaRole": "off",
+        "useValidAriaValues": "off",
+        "useValidAutocomplete": "off",
+        "useValidLang": "off"
+      },
+      "style": {
+        "useSingleVarDeclarator": "error",
+        "noParameterAssign": "off",
+        "noUselessElse": "off",
+        "noNonNullAssertion": "off",
+        "useNumberNamespace": "off",
+        "noUnusedTemplateLiteral": "off",
+        "useFilenamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": true,
+            "requireAscii": true,
+            "filenameCases": ["kebab-case", "export"]
+          }
+        },
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "noInferrableTypes": "error"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "tscircuit-bleeding",
-  "module": "index.ts",
+  "module": "./src/index.ts",
   "type": "module",
   "private": true,
+  "scripts": {
+    "build": "bun run src/index.ts build",
+    "format": "bunx prettier --write ."
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "private": true,
   "scripts": {
     "build": "bun run src/index.ts build",
-    "format": "bunx prettier --write ."
+    "format": "biome format --write .",
+    "format:check": "biome format ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.2.4",
     "@types/bun": "latest",
-    "prettier": "^3.3.3",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,0 +1,294 @@
+import { stat, mkdir, writeFile, rename } from "node:fs/promises";
+import { basename, isAbsolute, join, relative } from "node:path";
+
+import { DIST_DIRECTORY, packageGroups, WORKSPACE_DIRECTORY } from "./config";
+import type { PackageConfig } from "./config";
+import { cloneOrUpdateRepo, getCurrentCommit } from "./git";
+import { runCommand } from "./utils/run-command";
+
+interface BuiltPackage {
+  config: PackageConfig;
+  repoDirectory: string;
+  packageDirectory: string;
+  commit: string;
+  tarballPath?: string;
+}
+
+export interface BuildOptions {
+  workspaceRoot?: string;
+  distDirectory?: string;
+}
+
+export interface BuildResult {
+  tarballPath: string;
+  manifestPath: string;
+  packages: BuiltPackage[];
+}
+
+const DEFAULT_INSTALL_COMMAND = ["bun", "install"];
+const DEFAULT_BUILD_COMMAND = ["bun", "run", "build"];
+const DEFAULT_ENV = { CI: "1" };
+
+function slugifyPackageName(name: string) {
+  return name.replace(/[^a-zA-Z0-9.-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function resolvePackageDirectory(workspaceRoot: string, config: PackageConfig) {
+  const repoDirectory = join(workspaceRoot, slugifyPackageName(config.name));
+  const packageDirectory = config.directory
+    ? join(repoDirectory, config.directory)
+    : repoDirectory;
+  return { repoDirectory, packageDirectory };
+}
+
+async function processDependency(
+  config: PackageConfig,
+  workspaceRoot: string,
+): Promise<BuiltPackage> {
+  const { repoDirectory, packageDirectory } = resolvePackageDirectory(
+    workspaceRoot,
+    config,
+  );
+
+  await cloneOrUpdateRepo(config.repo, repoDirectory, config.ref);
+
+  const installCommand = config.installCommand ?? DEFAULT_INSTALL_COMMAND;
+  const buildCommand = config.buildCommand ?? DEFAULT_BUILD_COMMAND;
+
+  if (!config.skipInstall && installCommand) {
+    await runCommand(installCommand, {
+      cwd: packageDirectory,
+      env: DEFAULT_ENV,
+      description: `Installing dependencies for ${config.name}`,
+    });
+  }
+
+  if (!config.skipBuild && buildCommand) {
+    await runCommand(buildCommand, {
+      cwd: packageDirectory,
+      env: DEFAULT_ENV,
+      description: `Building ${config.name}`,
+    });
+  }
+
+  const shouldLink = config.link ?? true;
+  if (shouldLink) {
+    await runCommand(["bun", "link"], {
+      cwd: packageDirectory,
+      env: DEFAULT_ENV,
+      description: `Linking ${config.name}`,
+    });
+  }
+
+  const commit = await getCurrentCommit(repoDirectory);
+
+  return {
+    config,
+    repoDirectory,
+    packageDirectory,
+    commit,
+  };
+}
+
+async function linkDependencies(
+  targetDirectory: string,
+  dependencies: BuiltPackage[],
+) {
+  for (const dependency of dependencies) {
+    const shouldLink = dependency.config.link ?? true;
+    if (!shouldLink) continue;
+
+    await runCommand(["bun", "link", dependency.config.name], {
+      cwd: targetDirectory,
+      env: DEFAULT_ENV,
+      description: `Linking dependency ${dependency.config.name}`,
+    });
+  }
+}
+
+function formatTimestamp(date: Date) {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+  ].join("-");
+}
+
+async function createTarball(
+  packageDirectory: string,
+  distDirectory: string,
+  prefix = "tscircuit-bleeding",
+) {
+  await mkdir(distDirectory, { recursive: true });
+
+  const { stdout } = await runCommand(
+    ["npm", "pack", "--json", "--pack-destination", distDirectory],
+    {
+      cwd: packageDirectory,
+      captureOutput: true,
+      description: `Packing ${basename(packageDirectory)}`,
+    },
+  );
+
+  if (!stdout) {
+    throw new Error("npm pack did not return output");
+  }
+
+  const trimmed = stdout.trim();
+  const parsed = JSON.parse(trimmed);
+  const packEntries = Array.isArray(parsed) ? parsed : [parsed];
+  if (packEntries.length === 0 || !packEntries[0].filename) {
+    throw new Error(`Unexpected npm pack response: ${trimmed}`);
+  }
+
+  const [firstEntry] = packEntries;
+  const originalTarballPath = join(distDirectory, firstEntry.filename);
+  const timestamp = formatTimestamp(new Date());
+  const newFilename = `${prefix}-${timestamp}.tgz`;
+  const newTarballPath = join(distDirectory, newFilename);
+
+  await rename(originalTarballPath, newTarballPath);
+
+  return newTarballPath;
+}
+
+async function writeManifest(
+  packages: BuiltPackage[],
+  tarballPath: string,
+  distDirectory: string,
+) {
+  const tarballStats = await stat(tarballPath);
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    tarball: {
+      filename: basename(tarballPath),
+      relativePath: relative(distDirectory, tarballPath),
+      size: tarballStats.size,
+    },
+    packages: packages.map((pkg) => {
+      const entry: Record<string, string> = {
+        name: pkg.config.name,
+        repo: pkg.config.repo,
+        ref: pkg.config.ref ?? "main",
+        commit: pkg.commit,
+        workspacePath: relative(process.cwd(), pkg.packageDirectory),
+      };
+
+      if (pkg.tarballPath) {
+        entry.tarball = basename(pkg.tarballPath);
+      }
+
+      return entry;
+    }),
+  };
+
+  const manifestPath = join(distDirectory, "build-manifest.json");
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return manifestPath;
+}
+
+export async function buildBleeding(
+  options: BuildOptions = {},
+): Promise<BuildResult> {
+  const workspaceRoot = options.workspaceRoot
+    ? isAbsolute(options.workspaceRoot)
+      ? options.workspaceRoot
+      : join(process.cwd(), options.workspaceRoot)
+    : join(process.cwd(), WORKSPACE_DIRECTORY);
+  const distDirectory = options.distDirectory
+    ? isAbsolute(options.distDirectory)
+      ? options.distDirectory
+      : join(process.cwd(), options.distDirectory)
+    : join(process.cwd(), DIST_DIRECTORY);
+
+  await mkdir(workspaceRoot, { recursive: true });
+  await mkdir(distDirectory, { recursive: true });
+
+  const groups = [...packageGroups];
+  if (groups.length === 0) {
+    throw new Error("No package groups configured");
+  }
+
+  const finalGroup = groups.pop();
+  if (!finalGroup) {
+    throw new Error("Missing final package group");
+  }
+
+  const builtPackages: BuiltPackage[] = [];
+
+  for (const group of groups) {
+    console.log(`\n=== Building ${group.name} ===`);
+    const results = await Promise.all(
+      group.packages.map((pkg) => processDependency(pkg, workspaceRoot)),
+    );
+    builtPackages.push(...results);
+  }
+
+  console.log(`\n=== Building ${finalGroup.name} ===`);
+
+  const finalPackages: BuiltPackage[] = [];
+
+  for (const pkg of finalGroup.packages) {
+    const { repoDirectory, packageDirectory } = resolvePackageDirectory(
+      workspaceRoot,
+      pkg,
+    );
+
+    await cloneOrUpdateRepo(pkg.repo, repoDirectory, pkg.ref);
+
+    const installCommand = pkg.installCommand ?? DEFAULT_INSTALL_COMMAND;
+    if (!pkg.skipInstall && installCommand) {
+      await runCommand(installCommand, {
+        cwd: packageDirectory,
+        env: DEFAULT_ENV,
+        description: `Installing dependencies for ${pkg.name}`,
+      });
+    }
+
+    await linkDependencies(packageDirectory, builtPackages);
+
+    const buildCommand = pkg.buildCommand ?? DEFAULT_BUILD_COMMAND;
+    if (!pkg.skipBuild && buildCommand) {
+      await runCommand(buildCommand, {
+        cwd: packageDirectory,
+        env: DEFAULT_ENV,
+        description: `Building ${pkg.name}`,
+      });
+    }
+
+    const commit = await getCurrentCommit(repoDirectory);
+    const tarballPath = await createTarball(packageDirectory, distDirectory);
+
+    const builtPackage: BuiltPackage = {
+      config: pkg,
+      repoDirectory,
+      packageDirectory,
+      commit,
+      tarballPath,
+    };
+
+    finalPackages.push(builtPackage);
+    builtPackages.push(builtPackage);
+  }
+
+  const primaryTarball = finalPackages[0]?.tarballPath;
+  if (!primaryTarball) {
+    throw new Error("No tarball produced");
+  }
+
+  const manifestPath = await writeManifest(
+    builtPackages,
+    primaryTarball,
+    distDirectory,
+  );
+
+  return {
+    tarballPath: primaryTarball,
+    manifestPath,
+    packages: builtPackages,
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,31 +1,31 @@
 export interface PackageConfig {
   /** Package name used for linking */
-  name: string;
+  name: string
   /** Git repository URL */
-  repo: string;
+  repo: string
   /** Branch or ref to check out (defaults to main) */
-  ref?: string;
+  ref?: string
   /** Optional subdirectory that contains the package */
-  directory?: string;
+  directory?: string
   /** Override the install command */
-  installCommand?: string[];
+  installCommand?: string[]
   /** Override the build command */
-  buildCommand?: string[];
+  buildCommand?: string[]
   /** Whether to run `bun link` after building (defaults to true) */
-  link?: boolean;
+  link?: boolean
   /** Skip installation step */
-  skipInstall?: boolean;
+  skipInstall?: boolean
   /** Skip build step */
-  skipBuild?: boolean;
+  skipBuild?: boolean
 }
 
 export interface PackageGroup {
-  name: string;
-  packages: PackageConfig[];
+  name: string
+  packages: PackageConfig[]
 }
 
-const DEFAULT_BUILD_COMMAND = ["bun", "run", "build"];
-const DEFAULT_INSTALL_COMMAND = ["bun", "install"];
+const DEFAULT_BUILD_COMMAND = ["bun", "run", "build"]
+const DEFAULT_INSTALL_COMMAND = ["bun", "install"]
 
 export const packageGroups: PackageGroup[] = [
   {
@@ -97,9 +97,9 @@ export const packageGroups: PackageGroup[] = [
       },
     ],
   },
-];
+]
 
-export const DEFAULT_REF = "main";
-export const DEFAULT_LINK_BEHAVIOUR = true;
-export const WORKSPACE_DIRECTORY = "workdir";
-export const DIST_DIRECTORY = "dist";
+export const DEFAULT_REF = "main"
+export const DEFAULT_LINK_BEHAVIOUR = true
+export const WORKSPACE_DIRECTORY = "workdir"
+export const DIST_DIRECTORY = "dist"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,105 @@
+export interface PackageConfig {
+  /** Package name used for linking */
+  name: string;
+  /** Git repository URL */
+  repo: string;
+  /** Branch or ref to check out (defaults to main) */
+  ref?: string;
+  /** Optional subdirectory that contains the package */
+  directory?: string;
+  /** Override the install command */
+  installCommand?: string[];
+  /** Override the build command */
+  buildCommand?: string[];
+  /** Whether to run `bun link` after building (defaults to true) */
+  link?: boolean;
+  /** Skip installation step */
+  skipInstall?: boolean;
+  /** Skip build step */
+  skipBuild?: boolean;
+}
+
+export interface PackageGroup {
+  name: string;
+  packages: PackageConfig[];
+}
+
+const DEFAULT_BUILD_COMMAND = ["bun", "run", "build"];
+const DEFAULT_INSTALL_COMMAND = ["bun", "install"];
+
+export const packageGroups: PackageGroup[] = [
+  {
+    name: "Group 1",
+    packages: [
+      {
+        name: "@tscircuit/core",
+        repo: "https://github.com/tscircuit/core.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+      {
+        name: "@tscircuit/pcb-viewer",
+        repo: "https://github.com/tscircuit/pcb-viewer.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+      {
+        name: "@tscircuit/schematic-viewer",
+        repo: "https://github.com/tscircuit/schematic-viewer.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+      {
+        name: "@tscircuit/3d-viewer",
+        repo: "https://github.com/tscircuit/3d-viewer.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+    ],
+  },
+  {
+    name: "Group 2",
+    packages: [
+      {
+        name: "@tscircuit/eval",
+        repo: "https://github.com/tscircuit/eval.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+      {
+        name: "@tscircuit/runframe",
+        repo: "https://github.com/tscircuit/runframe.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+    ],
+  },
+  {
+    name: "Group 3",
+    packages: [
+      {
+        name: "@tscircuit/cli",
+        repo: "https://github.com/tscircuit/cli.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+      },
+    ],
+  },
+  {
+    name: "Group 4",
+    packages: [
+      {
+        name: "tscircuit",
+        repo: "https://github.com/tscircuit/tscircuit.git",
+        buildCommand: DEFAULT_BUILD_COMMAND,
+        installCommand: DEFAULT_INSTALL_COMMAND,
+        link: false,
+      },
+    ],
+  },
+];
+
+export const DEFAULT_REF = "main";
+export const DEFAULT_LINK_BEHAVIOUR = true;
+export const WORKSPACE_DIRECTORY = "workdir";
+export const DIST_DIRECTORY = "dist";

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,20 +1,20 @@
-import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { existsSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { dirname } from "node:path"
 
-import { DEFAULT_REF } from "./config";
-import { runCommand } from "./utils/run-command";
+import { DEFAULT_REF } from "./config"
+import { runCommand } from "./utils/run-command"
 
 export async function cloneOrUpdateRepo(
   repo: string,
   destination: string,
   ref: string = DEFAULT_REF,
 ) {
-  const parent = dirname(destination);
-  await mkdir(parent, { recursive: true });
+  const parent = dirname(destination)
+  await mkdir(parent, { recursive: true })
 
   if (!existsSync(destination)) {
-    console.log(`Cloning ${repo} -> ${destination} (${ref})`);
+    console.log(`Cloning ${repo} -> ${destination} (${ref})`)
     await runCommand([
       "git",
       "clone",
@@ -24,10 +24,10 @@ export async function cloneOrUpdateRepo(
       ref,
       repo,
       destination,
-    ]);
+    ])
   } else {
-    console.log(`Updating ${destination} (${ref})`);
-    await runCommand(["git", "-C", destination, "fetch", "origin", ref]);
+    console.log(`Updating ${destination} (${ref})`)
+    await runCommand(["git", "-C", destination, "fetch", "origin", ref])
     await runCommand([
       "git",
       "-C",
@@ -35,8 +35,8 @@ export async function cloneOrUpdateRepo(
       "reset",
       "--hard",
       `origin/${ref}`,
-    ]);
-    await runCommand(["git", "-C", destination, "clean", "-fd"]);
+    ])
+    await runCommand(["git", "-C", destination, "clean", "-fd"])
   }
 }
 
@@ -44,11 +44,11 @@ export async function getCurrentCommit(directory: string): Promise<string> {
   const { stdout } = await runCommand(
     ["git", "-C", directory, "rev-parse", "HEAD"],
     { captureOutput: true },
-  );
+  )
 
   if (!stdout) {
-    throw new Error(`Failed to read commit for ${directory}`);
+    throw new Error(`Failed to read commit for ${directory}`)
   }
 
-  return stdout.trim();
+  return stdout.trim()
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { DEFAULT_REF } from "./config";
+import { runCommand } from "./utils/run-command";
+
+export async function cloneOrUpdateRepo(
+  repo: string,
+  destination: string,
+  ref: string = DEFAULT_REF,
+) {
+  const parent = dirname(destination);
+  await mkdir(parent, { recursive: true });
+
+  if (!existsSync(destination)) {
+    console.log(`Cloning ${repo} -> ${destination} (${ref})`);
+    await runCommand([
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      ref,
+      repo,
+      destination,
+    ]);
+  } else {
+    console.log(`Updating ${destination} (${ref})`);
+    await runCommand(["git", "-C", destination, "fetch", "origin", ref]);
+    await runCommand([
+      "git",
+      "-C",
+      destination,
+      "reset",
+      "--hard",
+      `origin/${ref}`,
+    ]);
+    await runCommand(["git", "-C", destination, "clean", "-fd"]);
+  }
+}
+
+export async function getCurrentCommit(directory: string): Promise<string> {
+  const { stdout } = await runCommand(
+    ["git", "-C", directory, "rev-parse", "HEAD"],
+    { captureOutput: true },
+  );
+
+  if (!stdout) {
+    throw new Error(`Failed to read commit for ${directory}`);
+  }
+
+  return stdout.trim();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,63 +1,61 @@
-import { buildBleeding } from "./build";
-import type { BuildOptions } from "./build";
+import { buildBleeding } from "./build"
+import type { BuildOptions } from "./build"
 
 function printUsage() {
-  console.log(`Usage: bun run src/index.ts [command] [options]\n`);
-  console.log("Commands:");
+  console.log(`Usage: bun run src/index.ts [command] [options]\n`)
+  console.log("Commands:")
   console.log(
     "  build           Clone, build, link and package the bleeding release (default)",
-  );
-  console.log("  help            Show this message\n");
-  console.log("Options:");
+  )
+  console.log("  help            Show this message\n")
+  console.log("Options:")
   console.log(
     "  --workspace <path>  Override workspace directory (default: workdir)",
-  );
-  console.log(
-    "  --dist <path>       Override output directory (default: dist)",
-  );
+  )
+  console.log("  --dist <path>       Override output directory (default: dist)")
 }
 
 function parseOptions(args: string[]): BuildOptions {
-  const options: BuildOptions = {};
+  const options: BuildOptions = {}
 
   for (let index = 0; index < args.length; index++) {
-    const arg = args[index];
+    const arg = args[index]
     switch (arg) {
       case "--workspace":
       case "--workdir": {
-        const next = args[++index];
-        if (!next) throw new Error(`${arg} requires a value`);
-        options.workspaceRoot = next;
-        break;
+        const next = args[++index]
+        if (!next) throw new Error(`${arg} requires a value`)
+        options.workspaceRoot = next
+        break
       }
       case "--dist": {
-        const next = args[++index];
-        if (!next) throw new Error("--dist requires a value");
-        options.distDirectory = next;
-        break;
+        const next = args[++index]
+        if (!next) throw new Error("--dist requires a value")
+        options.distDirectory = next
+        break
       }
       default: {
-        throw new Error(`Unknown option: ${arg}`);
+        throw new Error(`Unknown option: ${arg}`)
       }
     }
   }
 
-  return options;
+  return options
 }
 
 async function runBuild(args: string[]) {
-  const options = parseOptions(args);
-  const result = await buildBleeding(options);
-  console.log(`\nTarball created at: ${result.tarballPath}`);
-  console.log(`Manifest written to: ${result.manifestPath}`);
+  const options = parseOptions(args)
+  const result = await buildBleeding(options)
+  console.log(`\nTarball created at: ${result.tarballPath}`)
+  console.log(`Manifest written to: ${result.manifestPath}`)
 }
 
 async function main() {
-  const [, , commandOrOption, ...rest] = Bun.argv;
+  const [, , commandOrOption, ...rest] = Bun.argv
 
   if (!commandOrOption || commandOrOption === "build") {
-    await runBuild(rest);
-    return;
+    await runBuild(rest)
+    return
   }
 
   if (
@@ -65,24 +63,24 @@ async function main() {
     commandOrOption === "--help" ||
     commandOrOption === "-h"
   ) {
-    printUsage();
-    return;
+    printUsage()
+    return
   }
 
   if (commandOrOption.startsWith("--")) {
-    await runBuild([commandOrOption, ...rest]);
-    return;
+    await runBuild([commandOrOption, ...rest])
+    return
   }
 
-  throw new Error(`Unknown command: ${commandOrOption}`);
+  throw new Error(`Unknown command: ${commandOrOption}`)
 }
 
 if (import.meta.main) {
   main().catch((error) => {
-    console.error(error instanceof Error ? error.message : error);
-    process.exit(1);
-  });
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
 }
 
-export { buildBleeding } from "./build";
-export type { BuildOptions, BuildResult } from "./build";
+export { buildBleeding } from "./build"
+export type { BuildOptions, BuildResult } from "./build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,88 @@
+import { buildBleeding } from "./build";
+import type { BuildOptions } from "./build";
+
+function printUsage() {
+  console.log(`Usage: bun run src/index.ts [command] [options]\n`);
+  console.log("Commands:");
+  console.log(
+    "  build           Clone, build, link and package the bleeding release (default)",
+  );
+  console.log("  help            Show this message\n");
+  console.log("Options:");
+  console.log(
+    "  --workspace <path>  Override workspace directory (default: workdir)",
+  );
+  console.log(
+    "  --dist <path>       Override output directory (default: dist)",
+  );
+}
+
+function parseOptions(args: string[]): BuildOptions {
+  const options: BuildOptions = {};
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    switch (arg) {
+      case "--workspace":
+      case "--workdir": {
+        const next = args[++index];
+        if (!next) throw new Error(`${arg} requires a value`);
+        options.workspaceRoot = next;
+        break;
+      }
+      case "--dist": {
+        const next = args[++index];
+        if (!next) throw new Error("--dist requires a value");
+        options.distDirectory = next;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown option: ${arg}`);
+      }
+    }
+  }
+
+  return options;
+}
+
+async function runBuild(args: string[]) {
+  const options = parseOptions(args);
+  const result = await buildBleeding(options);
+  console.log(`\nTarball created at: ${result.tarballPath}`);
+  console.log(`Manifest written to: ${result.manifestPath}`);
+}
+
+async function main() {
+  const [, , commandOrOption, ...rest] = Bun.argv;
+
+  if (!commandOrOption || commandOrOption === "build") {
+    await runBuild(rest);
+    return;
+  }
+
+  if (
+    commandOrOption === "help" ||
+    commandOrOption === "--help" ||
+    commandOrOption === "-h"
+  ) {
+    printUsage();
+    return;
+  }
+
+  if (commandOrOption.startsWith("--")) {
+    await runBuild([commandOrOption, ...rest]);
+    return;
+  }
+
+  throw new Error(`Unknown command: ${commandOrOption}`);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}
+
+export { buildBleeding } from "./build";
+export type { BuildOptions, BuildResult } from "./build";

--- a/src/utils/run-command.ts
+++ b/src/utils/run-command.ts
@@ -1,0 +1,65 @@
+import { mkdir } from "node:fs/promises";
+
+export interface RunCommandOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  /** When true, stdout/stderr will be captured and returned */
+  captureOutput?: boolean;
+  /** Optional human-friendly description for logging */
+  description?: string;
+}
+
+export interface RunCommandResult {
+  stdout?: string;
+  stderr?: string;
+}
+
+async function ensureDirectoryExists(path?: string) {
+  if (!path) return;
+  await mkdir(path, { recursive: true });
+}
+
+export async function runCommand(
+  cmd: string[],
+  options: RunCommandOptions = {},
+): Promise<RunCommandResult> {
+  const { cwd, env, captureOutput = false, description } = options;
+
+  if (description) {
+    console.log(description);
+  }
+
+  if (cwd) {
+    await ensureDirectoryExists(cwd);
+  }
+
+  const subprocess = Bun.spawn({
+    cmd,
+    cwd,
+    env: env ? { ...process.env, ...env } : process.env,
+    stdout: captureOutput ? "pipe" : "inherit",
+    stderr: captureOutput ? "pipe" : "inherit",
+  });
+
+  const exitCode = await subprocess.exited;
+
+  let stdout: string | undefined;
+  let stderr: string | undefined;
+
+  if (captureOutput && subprocess.stdout) {
+    stdout = await new Response(subprocess.stdout).text();
+  }
+
+  if (captureOutput && subprocess.stderr) {
+    stderr = await new Response(subprocess.stderr).text();
+  }
+
+  if (exitCode !== 0) {
+    const errorMessage =
+      `Command failed (${cmd.join(" ")}): exit code ${exitCode}` +
+      (stderr ? `\n${stderr}` : "");
+    throw new Error(errorMessage);
+  }
+
+  return { stdout, stderr };
+}

--- a/src/utils/run-command.ts
+++ b/src/utils/run-command.ts
@@ -1,36 +1,36 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir } from "node:fs/promises"
 
 export interface RunCommandOptions {
-  cwd?: string;
-  env?: Record<string, string>;
+  cwd?: string
+  env?: Record<string, string>
   /** When true, stdout/stderr will be captured and returned */
-  captureOutput?: boolean;
+  captureOutput?: boolean
   /** Optional human-friendly description for logging */
-  description?: string;
+  description?: string
 }
 
 export interface RunCommandResult {
-  stdout?: string;
-  stderr?: string;
+  stdout?: string
+  stderr?: string
 }
 
 async function ensureDirectoryExists(path?: string) {
-  if (!path) return;
-  await mkdir(path, { recursive: true });
+  if (!path) return
+  await mkdir(path, { recursive: true })
 }
 
 export async function runCommand(
   cmd: string[],
   options: RunCommandOptions = {},
 ): Promise<RunCommandResult> {
-  const { cwd, env, captureOutput = false, description } = options;
+  const { cwd, env, captureOutput = false, description } = options
 
   if (description) {
-    console.log(description);
+    console.log(description)
   }
 
   if (cwd) {
-    await ensureDirectoryExists(cwd);
+    await ensureDirectoryExists(cwd)
   }
 
   const subprocess = Bun.spawn({
@@ -39,27 +39,27 @@ export async function runCommand(
     env: env ? { ...process.env, ...env } : process.env,
     stdout: captureOutput ? "pipe" : "inherit",
     stderr: captureOutput ? "pipe" : "inherit",
-  });
+  })
 
-  const exitCode = await subprocess.exited;
+  const exitCode = await subprocess.exited
 
-  let stdout: string | undefined;
-  let stderr: string | undefined;
+  let stdout: string | undefined
+  let stderr: string | undefined
 
   if (captureOutput && subprocess.stdout) {
-    stdout = await new Response(subprocess.stdout).text();
+    stdout = await new Response(subprocess.stdout).text()
   }
 
   if (captureOutput && subprocess.stderr) {
-    stderr = await new Response(subprocess.stderr).text();
+    stderr = await new Response(subprocess.stderr).text()
   }
 
   if (exitCode !== 0) {
     const errorMessage =
       `Command failed (${cmd.join(" ")}): exit code ${exitCode}` +
-      (stderr ? `\n${stderr}` : "");
-    throw new Error(errorMessage);
+      (stderr ? `\n${stderr}` : "")
+    throw new Error(errorMessage)
   }
 
-  return { stdout, stderr };
+  return { stdout, stderr }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["workdir", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add configuration and CLI entrypoint for running the bleeding build pipeline
- implement orchestration that clones, installs, builds, links packages, and produces a tarball plus manifest
- document how to run the pipeline while ignoring generated workspaces and adjusting TypeScript config

## Testing
- bun run build
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c8e2a533e4832e9d7a192ce6baadea