### PR TITLE
feat: bootstrap bleeding build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,5 @@
-# dependencies (bun install)
 node_modules
-
-# output
-out
-dist
+/.turbo
+/.tscircuit-bleeding
+/dist
 *.tgz
-
-# code coverage
-coverage
-*.lcov
-
-# logs
-logs
-_.log
-report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
-
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
-
-# caches
-.eslintcache
-.cache
-*.tsbuildinfo
-
-# IntelliJ based IDEs
-.idea
-
-# Finder (MacOS) folder config
-.DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+.turbo
+.tscircuit-bleeding
+dist
+
+# Generated tarballs
+*.tgz

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -26,5 +26,50 @@ the group, but the group should be built in order.
 - Group 4
   - tscircuit
 
-
 These packages have dependencies on one another, e.g. @tscircuit/runframe depends on @tscircuit/pcb-viewer, so @tscircuit/pcb-viewer needs to be built first. They are universally built with `bun run build`. Some dependencies will depend on later dependencies- this is OK. Where a later dependency is required, we just use the version in the package.json file.
+
+## Build pipeline
+
+The repository now ships with a repeatable build pipeline that clones, builds, and bundles
+the bleeding-edge versions of the stack. Everything is orchestrated through Turbo and Bun
+scripts so that a single command can fetch the latest code, rebuild it, and produce a
+distribution tarball.
+
+### Prerequisites
+
+- Bun (used for scripting and the package builds)
+- Git
+- npm (used for packing the individual packages and the final bundle)
+
+### Commands
+
+| Command                  | Description                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `bun run bootstrap`      | Clones or updates each dependency repository into `.tscircuit-bleeding/repos`.             |
+| `bun run build-packages` | Runs installs/builds for every package in the configured order and writes build manifests. |
+| `bun run bundle`         | Builds everything (bootstrap + build) and assembles a bundle tarball in `dist/`.           |
+| `bun run clean`          | Removes the workspace (`.tscircuit-bleeding/`) and `dist/` output.                         |
+
+The same sequence can be executed through Turbo with `turbo run bundle` if you prefer the
+Turbo task runner UX.
+
+### Environment overrides
+
+The build scripts can be tuned via environment variables when you need faster experiments
+or partial builds:
+
+- `TSCB_GROUP_FILTER=group-1,group-2` – only operate on the listed build groups.
+- `TSCB_CONCURRENCY=1` – force a specific level of parallelism (useful when debugging).
+- `TSCB_DISABLE_PATCH=1` – avoid rewriting `package.json` files to point at local clones.
+- `TSCB_SKIP_BUILDS=1` – skip `bun install`/`bun run build` and produce manifests only.
+- `TSCB_SKIP_PACKAGE_PACKS=1` – skip `npm pack` and record placeholder artifacts in the bundle.
+
+### Outputs
+
+- **`.tscircuit-bleeding/repos/`** – working copies of each dependency repository.
+- **`.tscircuit-bleeding/manifests/`** – JSON manifests capturing build metadata (commit, version, local links).
+- **`.tscircuit-bleeding/packs/`** – `npm pack` output for every dependency after a successful build.
+- **`dist/tscircuit-bleeding-<timestamp>.tgz`** – the final bundle tarball containing manifests and all dependency tarballs.
+
+The final tarball includes a `manifest.json` that records exactly which commit and version
+were packaged, making it easy to audit or reproduce a build.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,20 @@
 {
   "name": "tscircuit-bleeding",
-  "module": "index.ts",
+  "module": "src/index.ts",
   "type": "module",
   "private": true,
+  "scripts": {
+    "bootstrap": "bun run src/index.ts bootstrap",
+    "build-packages": "bun run src/index.ts build",
+    "bundle": "bun run src/index.ts bundle",
+    "generate-tgz": "bun run src/index.ts bundle",
+    "clean": "bun run src/index.ts clean",
+    "format": "prettier --write ."
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "prettier": "^3.3.3",
+    "turbo": "^2.1.1"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/config/build-plan.ts
+++ b/src/config/build-plan.ts
@@ -1,0 +1,51 @@
+import type { BuildGroup, RepoConfig } from "../types";
+
+function repoConfig(
+  packageName: string,
+  repositoryPath: string,
+  overrides: Partial<RepoConfig> = {},
+): RepoConfig {
+  const dirName = packageName.replace(/^@/, "").replace(/[\/]/g, "-");
+  return {
+    packageName,
+    repository: repositoryPath.startsWith("http")
+      ? repositoryPath
+      : `https://github.com/${repositoryPath.replace(/^\//, "").replace(/\.git$/, "")}.git`,
+    ref: "main",
+    dirName,
+    installCommand: ["bun", "install"],
+    buildCommand: ["bun", "run", "build"],
+    ...overrides,
+  } satisfies RepoConfig;
+}
+
+export const BUILD_PLAN: BuildGroup[] = [
+  {
+    id: "group-1",
+    title: "Viewer foundations",
+    packages: [
+      repoConfig("@tscircuit/core", "tscircuit/core"),
+      repoConfig("@tscircuit/pcb-viewer", "tscircuit/pcb-viewer"),
+      repoConfig("@tscircuit/schematic-viewer", "tscircuit/schematic-viewer"),
+      repoConfig("@tscircuit/3d-viewer", "tscircuit/3d-viewer"),
+    ],
+  },
+  {
+    id: "group-2",
+    title: "Runtime packages",
+    packages: [
+      repoConfig("@tscircuit/eval", "tscircuit/eval"),
+      repoConfig("@tscircuit/runframe", "tscircuit/runframe"),
+    ],
+  },
+  {
+    id: "group-3",
+    title: "CLI",
+    packages: [repoConfig("@tscircuit/cli", "tscircuit/cli")],
+  },
+  {
+    id: "group-4",
+    title: "Top-level tscircuit",
+    packages: [repoConfig("tscircuit", "tscircuit/tscircuit")],
+  },
+];

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,61 @@
+import os from "node:os";
+import { join } from "node:path";
+
+import { BUILD_PLAN } from "./config/build-plan";
+import { ensureDir } from "./utils/fs";
+import type { BuildContext, WorkspacePaths } from "./types";
+
+function determineConcurrency(): number {
+  const fromEnv = process.env.TSCB_CONCURRENCY;
+  if (fromEnv) {
+    const parsed = Number(fromEnv);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+  }
+  const cpuCount = os.cpus()?.length ?? 2;
+  return Math.max(1, Math.min(4, cpuCount - 1));
+}
+
+function parseGroupFilter(): Set<string> | undefined {
+  const raw = process.env.TSCB_GROUP_FILTER;
+  if (!raw) return undefined;
+  const groups = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  if (groups.length === 0) return undefined;
+  return new Set(groups);
+}
+
+export async function createContext(): Promise<BuildContext> {
+  const rootDir = process.cwd();
+  const workspaceDir = join(rootDir, ".tscircuit-bleeding");
+
+  const paths: WorkspacePaths = {
+    rootDir,
+    workspaceDir,
+    reposDir: join(workspaceDir, "repos"),
+    manifestsDir: join(workspaceDir, "manifests"),
+    packsDir: join(workspaceDir, "packs"),
+    bundleDir: join(workspaceDir, "bundle"),
+    distDir: join(rootDir, "dist"),
+  };
+
+  await Promise.all([
+    ensureDir(paths.workspaceDir),
+    ensureDir(paths.reposDir),
+    ensureDir(paths.manifestsDir),
+    ensureDir(paths.packsDir),
+    ensureDir(paths.bundleDir),
+    ensureDir(paths.distDir),
+  ]);
+
+  return {
+    plan: BUILD_PLAN,
+    paths,
+    concurrency: determineConcurrency(),
+    repoStates: new Map(),
+    groupFilter: parseGroupFilter(),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,49 @@
+import { createContext } from "./context";
+import { bootstrap } from "./steps/bootstrap";
+import { buildPackages } from "./steps/build";
+import { bundle } from "./steps/bundle";
+import { clean as cleanWorkspace } from "./steps/clean";
+
+async function run(command: string): Promise<void> {
+  if (command === "clean") {
+    const context = await createContext();
+    await cleanWorkspace(context);
+    return;
+  }
+
+  const context = await createContext();
+
+  switch (command) {
+    case "bootstrap": {
+      await bootstrap(context);
+      break;
+    }
+    case "build":
+    case "build-packages": {
+      await bootstrap(context);
+      await buildPackages(context);
+      break;
+    }
+    case "bundle":
+    case "generate-tgz": {
+      await bootstrap(context);
+      const manifests = await buildPackages(context);
+      await bundle(context, manifests);
+      break;
+    }
+    default: {
+      console.error(`Unknown command: ${command}`);
+      console.error("Available commands: bootstrap, build, bundle, clean");
+      process.exitCode = 1;
+    }
+  }
+}
+
+const command = (process.argv[2] ?? "bundle").toLowerCase();
+run(command).catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  if (error instanceof Error && error.stack) {
+    console.error(error.stack);
+  }
+  process.exitCode = 1;
+});

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,81 @@
+import { join } from "node:path";
+
+import type { BuildContext, RepoConfig, RepoState } from "../types";
+import { pathExists } from "../utils/fs";
+import { captureCommand, runCommand } from "../utils/command";
+
+function resolveDirName(config: RepoConfig): string {
+  return config.dirName ?? config.packageName.replace(/^@/, "").replace(/[\/]/g, "-");
+}
+
+function repoDir(context: BuildContext, config: RepoConfig): string {
+  return join(context.paths.reposDir, resolveDirName(config));
+}
+
+async function getCurrentBranch(directory: string): Promise<string> {
+  const { stdout } = await captureCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd: directory,
+  });
+  const branch = stdout.trim();
+  if (branch && branch !== "HEAD") {
+    return branch;
+  }
+  const remote = await captureCommand(["git", "remote", "show", "origin"], { cwd: directory });
+  const headLine = remote.stdout.split("\n").find((line) => line.includes("HEAD branch:"));
+  return headLine?.split(":")?.[1]?.trim() || "main";
+}
+
+async function checkoutBranch(directory: string, branch: string): Promise<void> {
+  await runCommand(["git", "checkout", branch], { cwd: directory });
+  await runCommand(["git", "reset", "--hard", `origin/${branch}`], { cwd: directory });
+}
+
+async function initializeSubmodules(directory: string): Promise<void> {
+  try {
+    await runCommand(["git", "submodule", "update", "--init", "--recursive"], { cwd: directory });
+  } catch (error) {
+    console.warn(
+      `Warning: failed to update submodules in ${directory}: ${(error as Error).message}`,
+    );
+  }
+}
+
+export async function ensureRepo(context: BuildContext, config: RepoConfig): Promise<RepoState> {
+  const directory = repoDir(context, config);
+  const gitDirectoryExists = await pathExists(join(directory, ".git"));
+
+  if (!gitDirectoryExists) {
+    const cloneArgs: string[] = [
+      "git",
+      "clone",
+      "--filter=blob:none",
+      "--single-branch",
+      "--depth",
+      "1",
+    ];
+    if (config.ref) {
+      cloneArgs.push("--branch", config.ref);
+    }
+    cloneArgs.push(config.repository, directory);
+    await runCommand(cloneArgs as [string, ...string[]]);
+    await initializeSubmodules(directory);
+  } else {
+    await runCommand(["git", "fetch", "--tags", "--prune", "origin"], { cwd: directory });
+    const branch = config.ref ?? (await getCurrentBranch(directory));
+    await checkoutBranch(directory, branch);
+    await initializeSubmodules(directory);
+  }
+
+  const branch = config.ref ?? (await getCurrentBranch(directory));
+  return {
+    config,
+    repoDir: directory,
+    dirName: resolveDirName(config),
+    branch,
+  } satisfies RepoState;
+}
+
+export async function getCurrentCommit(directory: string): Promise<string> {
+  const { stdout } = await captureCommand(["git", "rev-parse", "HEAD"], { cwd: directory });
+  return stdout.trim();
+}

--- a/src/lib/manifests.ts
+++ b/src/lib/manifests.ts
@@ -1,0 +1,34 @@
+import { join } from "node:path";
+
+import type { BuildContext, BuildManifest } from "../types";
+import { listFiles, readJson, writeJson } from "../utils/fs";
+
+export async function writeBuildManifest(
+  context: BuildContext,
+  manifest: BuildManifest,
+): Promise<string> {
+  const manifestPath = join(context.paths.manifestsDir, `${manifest.dirName}.json`);
+  await writeJson(manifestPath, manifest);
+  return manifestPath;
+}
+
+export async function loadBuildManifests(context: BuildContext): Promise<BuildManifest[]> {
+  const files = await listFiles(context.paths.manifestsDir);
+  const manifests: BuildManifest[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const manifestPath = join(context.paths.manifestsDir, file);
+    const manifest = await readJson<BuildManifest>(manifestPath);
+    manifests.push(manifest);
+  }
+
+  const groupOrder = new Map(context.plan.map((group, index) => [group.id, index] as const));
+  manifests.sort((a, b) => {
+    const groupCompare = (groupOrder.get(a.groupId) ?? 0) - (groupOrder.get(b.groupId) ?? 0);
+    if (groupCompare !== 0) return groupCompare;
+    return a.packageName.localeCompare(b.packageName);
+  });
+
+  return manifests;
+}

--- a/src/lib/package-json.ts
+++ b/src/lib/package-json.ts
@@ -1,0 +1,84 @@
+import { join, relative } from "node:path";
+
+import type { LocalPackageRef, PackageJson } from "../types";
+import { pathExists, readTextFile, writeJson, writeTextFile } from "../utils/fs";
+
+const PATCHED_SECTIONS = ["dependencies", "devDependencies", "optionalDependencies"] as const;
+
+function toPatchedValue(from: string, to: string): { value: string; relativePath: string } {
+  let relativePath = relative(from, to).replace(/\\/g, "/");
+  if (!relativePath.startsWith(".")) {
+    relativePath = `./${relativePath}`;
+  }
+  return { value: `file:${relativePath}`, relativePath };
+}
+
+export interface PackageJsonPatchResult {
+  original: PackageJson;
+  patched: PackageJson;
+  changed: boolean;
+  localDependencies: Record<string, { relativePath: string; originalVersion: string }>;
+  restore(): Promise<void>;
+}
+
+export interface PackageJsonPatchOptions {
+  disablePatch?: boolean;
+}
+
+export async function applyLocalDependencyPatches(
+  repoDir: string,
+  availablePackages: Map<string, LocalPackageRef>,
+  options: PackageJsonPatchOptions = {},
+): Promise<PackageJsonPatchResult> {
+  const disablePatch = options.disablePatch ?? false;
+  const packageJsonPath = join(repoDir, "package.json");
+  const metadataDir = join(repoDir, ".tscircuit-bleeding");
+  const backupPath = join(metadataDir, "package.json.original");
+
+  let originalContents: string;
+  if (await pathExists(backupPath)) {
+    originalContents = await readTextFile(backupPath);
+    await writeTextFile(packageJsonPath, originalContents);
+  } else {
+    originalContents = await readTextFile(packageJsonPath);
+    await writeTextFile(backupPath, originalContents);
+  }
+
+  const original = JSON.parse(originalContents) as PackageJson;
+  const patched = JSON.parse(JSON.stringify(original)) as PackageJson;
+  const localDependencies: Record<string, { relativePath: string; originalVersion: string }> = {};
+  let changed = false;
+
+  if (!disablePatch) {
+    for (const key of PATCHED_SECTIONS) {
+      const section = patched[key];
+      if (!section) continue;
+
+      for (const dependencyName of Object.keys(section)) {
+        const localPackage = availablePackages.get(dependencyName);
+        if (!localPackage) continue;
+        const originalVersion = section[dependencyName]!;
+        const { value, relativePath } = toPatchedValue(repoDir, localPackage.repoState.repoDir);
+        if (section[dependencyName] !== value) {
+          section[dependencyName] = value;
+          localDependencies[dependencyName] = { relativePath, originalVersion };
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    await writeJson(packageJsonPath, patched);
+  }
+
+  return {
+    original,
+    patched: disablePatch ? original : patched,
+    changed,
+    localDependencies,
+    restore: async () => {
+      await writeTextFile(packageJsonPath, originalContents);
+    },
+  };
+}

--- a/src/steps/bootstrap.ts
+++ b/src/steps/bootstrap.ts
@@ -1,0 +1,31 @@
+import type { BuildContext } from "../types";
+import { ensureRepo } from "../lib/git";
+import { mapWithConcurrency } from "../utils/concurrency";
+
+function cloneConcurrency(context: BuildContext, groupConcurrency?: number): number {
+  const base = groupConcurrency ?? context.concurrency;
+  return Math.max(1, Math.min(base, 3));
+}
+
+function shouldProcessGroup(context: BuildContext, groupId: string): boolean {
+  if (!context.groupFilter) return true;
+  return context.groupFilter.has(groupId);
+}
+
+export async function bootstrap(context: BuildContext): Promise<void> {
+  console.log("Bootstrapping repositories...");
+  for (const group of context.plan) {
+    if (!shouldProcessGroup(context, group.id)) {
+      console.log(`• ${group.title} (skipped)`);
+      continue;
+    }
+    console.log(`• ${group.title}`);
+    const concurrency = cloneConcurrency(context, group.concurrency);
+    await mapWithConcurrency(group.packages, concurrency, async (config) => {
+      const state = await ensureRepo(context, config);
+      context.repoStates.set(config.packageName, state);
+      console.log(`  ✓ ${config.packageName} ready at ${state.repoDir}`);
+      return state;
+    });
+  }
+}

--- a/src/steps/build.ts
+++ b/src/steps/build.ts
@@ -1,0 +1,114 @@
+import { relative } from "node:path";
+
+import type { BuildContext, BuildManifest, LocalPackageRef, RepoState } from "../types";
+import { mapWithConcurrency } from "../utils/concurrency";
+import { runCommand } from "../utils/command";
+import { applyLocalDependencyPatches } from "../lib/package-json";
+import { getCurrentCommit } from "../lib/git";
+import { writeBuildManifest } from "../lib/manifests";
+
+function toCommand(command: string[] | undefined, fallback: string[]): [string, ...string[]] {
+  const resolved = command && command.length > 0 ? command : fallback;
+  if (!resolved || resolved.length === 0) {
+    throw new Error("Commands must contain at least one argument");
+  }
+  return resolved as [string, ...string[]];
+}
+
+function repoStateOrThrow(state: RepoState | undefined, packageName: string): RepoState {
+  if (!state) {
+    throw new Error(`Repository state for ${packageName} is not available. Did you run bootstrap?`);
+  }
+  return state;
+}
+
+function shouldBuildGroup(context: BuildContext, groupId: string): boolean {
+  if (!context.groupFilter) return true;
+  return context.groupFilter.has(groupId);
+}
+
+async function buildSinglePackage(
+  context: BuildContext,
+  repoState: RepoState,
+  availablePackages: Map<string, LocalPackageRef>,
+  groupId: string,
+): Promise<BuildManifest> {
+  console.log(`  → Building ${repoState.config.packageName}`);
+  const skipBuild = process.env.TSCB_SKIP_BUILDS === "1";
+  const disablePatch = skipBuild || process.env.TSCB_DISABLE_PATCH === "1";
+  const patchResult = await applyLocalDependencyPatches(repoState.repoDir, availablePackages, {
+    disablePatch,
+  });
+  if (disablePatch && availablePackages.size > 0) {
+    console.log("    (local dependency patching disabled)");
+  }
+  const installCommand = toCommand(repoState.config.installCommand, ["bun", "install"]);
+  const buildCommand = toCommand(repoState.config.buildCommand, ["bun", "run", "build"]);
+
+  try {
+    if (skipBuild) {
+      console.log("    (skipping install/build commands)");
+    } else {
+      await runCommand(installCommand, { cwd: repoState.repoDir });
+      await runCommand(buildCommand, { cwd: repoState.repoDir });
+    }
+  } finally {
+    await patchResult.restore();
+  }
+
+  const commit = await getCurrentCommit(repoState.repoDir);
+  const packageName = patchResult.original.name ?? repoState.config.packageName;
+  const version = patchResult.original.version ?? "0.0.0";
+  const manifest: BuildManifest = {
+    packageName,
+    version,
+    repository: repoState.config.repository,
+    dirName: repoState.dirName,
+    commit,
+    ref: repoState.branch,
+    builtAt: new Date().toISOString(),
+    relativeRepoDir: relative(context.paths.rootDir, repoState.repoDir),
+    installCommand: [...installCommand],
+    buildCommand: [...buildCommand],
+    groupId,
+    localDependencies: patchResult.localDependencies,
+  };
+
+  await writeBuildManifest(context, manifest);
+  console.log(`  ✓ ${packageName}@${version} built`);
+
+  return manifest;
+}
+
+export async function buildPackages(context: BuildContext): Promise<BuildManifest[]> {
+  console.log("Building packages...");
+  const manifests: BuildManifest[] = [];
+  const availablePackages = new Map<string, LocalPackageRef>();
+
+  for (const group of context.plan) {
+    if (!shouldBuildGroup(context, group.id)) {
+      console.log(`• ${group.title} (skipped)`);
+      continue;
+    }
+    console.log(`• ${group.title}`);
+    const repoStates = group.packages.map((config) =>
+      repoStateOrThrow(context.repoStates.get(config.packageName), config.packageName),
+    );
+
+    const concurrency = Math.max(1, group.concurrency ?? context.concurrency);
+    const groupResults = await mapWithConcurrency(repoStates, concurrency, async (state) =>
+      buildSinglePackage(context, state, availablePackages, group.id),
+    );
+
+    for (const manifest of groupResults) {
+      const repoState = repoStateOrThrow(
+        context.repoStates.get(manifest.packageName),
+        manifest.packageName,
+      );
+      availablePackages.set(manifest.packageName, { manifest, repoState });
+      manifests.push(manifest);
+    }
+  }
+
+  return manifests;
+}

--- a/src/steps/bundle.ts
+++ b/src/steps/bundle.ts
@@ -1,0 +1,144 @@
+import { rename } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { BuildContext, BuildManifest } from "../types";
+import { loadBuildManifests } from "../lib/manifests";
+import { captureCommand } from "../utils/command";
+import { cleanDir, copyFileWithDirs, ensureDir, writeJson, writeTextFile } from "../utils/fs";
+import { createTimestamp } from "../utils/format";
+
+interface PackResult {
+  manifest: BuildManifest;
+  fileName: string;
+  filePath: string;
+  skipped: boolean;
+}
+
+async function packRepository(
+  context: BuildContext,
+  manifest: BuildManifest,
+  skipPack: boolean,
+): Promise<PackResult> {
+  const repositoryPath = join(context.paths.rootDir, manifest.relativeRepoDir);
+  if (skipPack) {
+    console.log(`  → Skipping pack for ${manifest.packageName}`);
+    const fileName = `${manifest.dirName}.placeholder.txt`;
+    const filePath = join(context.paths.packsDir, fileName);
+    await writeTextFile(
+      filePath,
+      `Packaging skipped for ${manifest.packageName}@${manifest.version}. Set TSCB_SKIP_PACKAGE_PACKS=0 to include real artifacts.\n`,
+    );
+    return { manifest, fileName, filePath, skipped: true };
+  }
+  console.log(`  → Packing ${manifest.packageName}`);
+  const result = await captureCommand(
+    ["npm", "pack", "--json", "--pack-destination", context.paths.packsDir],
+    { cwd: repositoryPath },
+  );
+  const parsed = JSON.parse(result.stdout) as Array<{ filename: string }>;
+  const fileName = parsed[0]?.filename;
+  if (!fileName) {
+    throw new Error(`npm pack did not produce an output for ${manifest.packageName}`);
+  }
+  const filePath = join(context.paths.packsDir, fileName);
+  console.log(`  ✓ ${manifest.packageName} packed (${fileName})`);
+  return { manifest, fileName, filePath, skipped: false };
+}
+
+export interface BundleManifest {
+  builtAt: string;
+  packages: Array<{
+    packageName: string;
+    version: string;
+    repository: string;
+    commit: string;
+    ref: string;
+    groupId: string;
+    tarballFile: string;
+    localDependencies: BuildManifest["localDependencies"];
+    skipped: boolean;
+  }>;
+}
+
+export interface BundleResult {
+  manifest: BundleManifest;
+  tarballPath: string;
+}
+
+export async function bundle(
+  context: BuildContext,
+  manifests?: BuildManifest[],
+): Promise<BundleResult> {
+  const buildManifests =
+    manifests && manifests.length > 0 ? manifests : await loadBuildManifests(context);
+  if (buildManifests.length === 0) {
+    throw new Error("No build manifests available. Run the build step first.");
+  }
+
+  await cleanDir(context.paths.packsDir);
+  const skipPackagePacks = process.env.TSCB_SKIP_PACKAGE_PACKS === "1";
+  const packResults: PackResult[] = [];
+  for (const manifest of buildManifests) {
+    packResults.push(await packRepository(context, manifest, skipPackagePacks));
+  }
+
+  await cleanDir(context.paths.bundleDir);
+  const timestamp = createTimestamp();
+  const packagesDir = join(context.paths.bundleDir, "packages");
+  await ensureDir(packagesDir);
+
+  for (const pack of packResults) {
+    const destination = join(packagesDir, pack.fileName);
+    await copyFileWithDirs(pack.filePath, destination);
+  }
+
+  const bundleManifest: BundleManifest = {
+    builtAt: timestamp.iso,
+    packages: packResults.map((pack) => ({
+      packageName: pack.manifest.packageName,
+      version: pack.manifest.version,
+      repository: pack.manifest.repository,
+      commit: pack.manifest.commit,
+      ref: pack.manifest.ref,
+      groupId: pack.manifest.groupId,
+      tarballFile: `packages/${pack.fileName}`,
+      localDependencies: pack.manifest.localDependencies,
+      skipped: pack.skipped,
+    })),
+  };
+
+  const bundlePackageJson = {
+    name: "tscircuit-bleeding",
+    version: `0.0.0-bleeding.${timestamp.semverFragment}`,
+    description: "Aggregated bleeding-edge build of the tscircuit stack.",
+    type: "module",
+    files: ["manifest.json", "packages/"],
+    keywords: ["tscircuit", "bleeding"],
+    tscircuitBleeding: bundleManifest,
+  } satisfies Record<string, unknown>;
+
+  await writeJson(join(context.paths.bundleDir, "package.json"), bundlePackageJson);
+  await writeJson(join(context.paths.bundleDir, "manifest.json"), bundleManifest);
+  await writeTextFile(
+    join(context.paths.bundleDir, "README.md"),
+    `# tscircuit bleeding bundle\n\nGenerated at ${timestamp.iso} UTC.\n`,
+  );
+
+  const packOutput = await captureCommand(
+    ["npm", "pack", "--json", "--pack-destination", context.paths.distDir],
+    { cwd: context.paths.bundleDir },
+  );
+  const packedBundle = JSON.parse(packOutput.stdout) as Array<{ filename: string }>;
+  const producedFile = packedBundle[0]?.filename;
+  if (!producedFile) {
+    throw new Error("npm pack failed to produce the final bundle tarball");
+  }
+
+  const producedPath = join(context.paths.distDir, producedFile);
+  const finalName = `tscircuit-bleeding-${timestamp.fileSafe}.tgz`;
+  const finalPath = join(context.paths.distDir, finalName);
+  await rename(producedPath, finalPath);
+  console.log(`✓ Bundle available at ${finalPath}`);
+
+  return { manifest: bundleManifest, tarballPath: finalPath };
+}

--- a/src/steps/clean.ts
+++ b/src/steps/clean.ts
@@ -1,0 +1,11 @@
+import { rm } from "node:fs/promises";
+
+import type { BuildContext } from "../types";
+
+export async function clean(context: BuildContext): Promise<void> {
+  await Promise.all([
+    rm(context.paths.workspaceDir, { recursive: true, force: true }),
+    rm(context.paths.distDir, { recursive: true, force: true }),
+  ]);
+  console.log("Workspace cleaned.");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,74 @@
+export type DependencyMap = Record<string, string>;
+
+export interface PackageJson {
+  name: string;
+  version?: string;
+  private?: boolean;
+  workspaces?: string[] | { packages?: string[] };
+  dependencies?: DependencyMap;
+  devDependencies?: DependencyMap;
+  optionalDependencies?: DependencyMap;
+  peerDependencies?: DependencyMap;
+  [key: string]: unknown;
+}
+
+export interface RepoConfig {
+  packageName: string;
+  repository: string;
+  ref?: string;
+  dirName?: string;
+  installCommand?: string[];
+  buildCommand?: string[];
+}
+
+export interface BuildGroup {
+  id: string;
+  title: string;
+  concurrency?: number;
+  packages: RepoConfig[];
+}
+
+export interface WorkspacePaths {
+  rootDir: string;
+  workspaceDir: string;
+  reposDir: string;
+  manifestsDir: string;
+  packsDir: string;
+  bundleDir: string;
+  distDir: string;
+}
+
+export interface RepoState {
+  config: RepoConfig;
+  repoDir: string;
+  dirName: string;
+  branch: string;
+}
+
+export interface BuildManifest {
+  packageName: string;
+  version: string;
+  repository: string;
+  dirName: string;
+  commit: string;
+  ref: string;
+  builtAt: string;
+  relativeRepoDir: string;
+  installCommand: string[];
+  buildCommand: string[];
+  groupId: string;
+  localDependencies: Record<string, { relativePath: string; originalVersion: string }>;
+}
+
+export interface BuildContext {
+  plan: BuildGroup[];
+  paths: WorkspacePaths;
+  concurrency: number;
+  repoStates: Map<string, RepoState>;
+  groupFilter?: Set<string>;
+}
+
+export interface LocalPackageRef {
+  manifest: BuildManifest;
+  repoState: RepoState;
+}

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,0 +1,73 @@
+import type { Subprocess } from "bun";
+
+export type Command = [string, ...string[]];
+
+export interface CommandOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  stdout?: "inherit" | "pipe" | "ignore";
+  stderr?: "inherit" | "pipe" | "ignore";
+}
+
+function createEnv(env?: Record<string, string | undefined>): Record<string, string> {
+  return {
+    ...process.env,
+    ...Object.fromEntries(Object.entries(env ?? {}).filter(([, value]) => value !== undefined)),
+  } as Record<string, string>;
+}
+
+async function waitForProcess(subprocess: Subprocess, command: Command): Promise<number> {
+  const exitCode = await subprocess.exited;
+  if (exitCode !== 0) {
+    throw new Error(`Command \`${command.join(" ")}\` exited with code ${exitCode}`);
+  }
+  return exitCode;
+}
+
+export async function runCommand(command: Command, options: CommandOptions = {}): Promise<void> {
+  const subprocess = Bun.spawn({
+    cmd: command,
+    cwd: options.cwd,
+    env: createEnv(options.env),
+    stdout: options.stdout ?? "inherit",
+    stderr: options.stderr ?? "inherit",
+  });
+
+  await waitForProcess(subprocess, command);
+}
+
+export interface CaptureCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function captureCommand(
+  command: Command,
+  options: CommandOptions = {},
+): Promise<CaptureCommandResult> {
+  const subprocess = Bun.spawn({
+    cmd: command,
+    cwd: options.cwd,
+    env: createEnv(options.env),
+    stdout: options.stdout ?? "pipe",
+    stderr: options.stderr ?? "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    subprocess.stdout ? new Response(subprocess.stdout).text() : "",
+    subprocess.stderr ? new Response(subprocess.stderr).text() : "",
+    subprocess.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const error = new Error(
+      `Command \`${command.join(" ")}\` exited with code ${exitCode}.\n${stderr.trim()}`,
+    );
+    (error as Error & { stdout?: string; stderr?: string }).stdout = stdout;
+    (error as Error & { stdout?: string; stderr?: string }).stderr = stderr;
+    throw error;
+  }
+
+  return { stdout, stderr, exitCode };
+}

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,27 @@
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  iterator: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (concurrency < 1) {
+    throw new Error("Concurrency must be at least 1");
+  }
+
+  const results: R[] = new Array(items.length);
+  let currentIndex = 0;
+
+  const runNext = async (): Promise<void> => {
+    const index = currentIndex;
+    if (index >= items.length) {
+      return;
+    }
+    currentIndex += 1;
+    const value = await iterator(items[index]!, index);
+    results[index] = value;
+    await runNext();
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => runNext());
+  await Promise.all(workers);
+  return results;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,18 @@
+export interface TimestampInfo {
+  iso: string;
+  fileSafe: string;
+  semverFragment: string;
+}
+
+function pad(value: number, length = 2): string {
+  return value.toString().padStart(length, "0");
+}
+
+export function createTimestamp(date = new Date()): TimestampInfo {
+  const iso = date.toISOString();
+  const fileSafe = iso.replace(/[:]/g, "-").replace(/\..+/, "");
+  const semverFragment = `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}${pad(
+    date.getUTCHours(),
+  )}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`;
+  return { iso, fileSafe, semverFragment };
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,59 @@
+import { copyFile, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export async function ensureDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function readJson<T>(path: string): Promise<T> {
+  const contents = await readFile(path, "utf8");
+  return JSON.parse(contents) as T;
+}
+
+export async function writeJson(path: string, value: unknown): Promise<void> {
+  await ensureDir(dirname(path));
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  await writeFile(path, serialized, "utf8");
+}
+
+export async function readTextFile(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+export async function writeTextFile(path: string, contents: string): Promise<void> {
+  await ensureDir(dirname(path));
+  await writeFile(path, contents, "utf8");
+}
+
+export async function cleanDir(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true });
+  await ensureDir(path);
+}
+
+export async function copyFileWithDirs(source: string, target: string): Promise<void> {
+  await ensureDir(dirname(target));
+  await copyFile(source, target);
+}
+
+export async function listFiles(path: string): Promise<string[]> {
+  try {
+    return await readdir(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "bootstrap": {
+      "outputs": [".tscircuit-bleeding/repos/**"]
+    },
+    "build-packages": {
+      "dependsOn": ["bootstrap"],
+      "outputs": [".tscircuit-bleeding/manifests/**"]
+    },
+    "bundle": {
+      "dependsOn": ["build-packages"],
+      "outputs": ["dist/*.tgz", ".tscircuit-bleeding/packs/**", ".tscircuit-bleeding/bundle/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Bun/Turbo-driven build pipeline with CLI entrypoint, repo bootstrapping, and manifest generation
- implement bundle packaging that can optionally skip heavy operations while still emitting manifest metadata
- document usage commands, environment overrides, and add formatting/turbo config to the repo

## Testing
- bunx tsc --noEmit
- bun run format
- CI=1 TSCB_DISABLE_PATCH=1 TSCB_GROUP_FILTER=group-1 TSCB_CONCURRENCY=1 TSCB_SKIP_BUILDS=1 TSCB_SKIP_PACKAGE_PACKS=1 bun run bundle

------
https://chatgpt.com/codex/tasks/task_b_68c8e29a95fc832eb548ba01a3954229