### PR TITLE
Bootstrap bleeding build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,23 @@
-# dependencies (bun install)
-node_modules
+# Dependencies
+node_modules/
 
-# output
-out
-dist
+# Bun
+bun.lockb
+
+# Build system workspace
+.tscircuit-workspace/
+workspace/
+.build-system/
+
+# yalc artifacts
+.yalc/
+yalc.lock
+
+# Logs & artifacts
+artifacts/
 *.tgz
+*.log
 
-# code coverage
-coverage
-*.lcov
-
-# logs
-logs
-_.log
-report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
-
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
-
-# caches
-.eslintcache
-.cache
-*.tsbuildinfo
-
-# IntelliJ based IDEs
-.idea
-
-# Finder (MacOS) folder config
+# IDE/editor
+.vscode/
 .DS_Store
-.vscode
-.aider*

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+import path from "node:path"
+import process from "node:process"
+import { BUILD_GROUPS } from "./src/config"
+import { runBuildSystem, DEFAULT_WORKSPACE_DIR } from "./src/build-system"
+import { pathExists, removeDir } from "./src/fs-utils"
+import {
+  logError,
+  logInfo,
+  logSuccess,
+  logTask,
+  logWarn,
+  separator,
+} from "./src/logger"
+import type { BuildGroup, BuildSystemOptions } from "./src/types"
+
+interface CliOptions extends BuildSystemOptions {}
+
+type CliCommand = "build" | "plan" | "clean"
+
+async function main(): Promise<void> {
+  const [, , ...rawArgs] = process.argv
+  const { command, optionArgs } = extractCommand(rawArgs)
+  let options: CliOptions
+  try {
+    options = parseOptions(optionArgs)
+  } catch (error) {
+    logError((error as Error).message)
+    process.exit(1)
+    return
+  }
+
+  switch (command) {
+    case "plan":
+      printPlan(BUILD_GROUPS)
+      break
+    case "clean":
+      await cleanWorkspace(options)
+      break
+    case "build":
+      await runBuild(options)
+      break
+    default:
+      logError(`Unknown command: ${command}`)
+      process.exit(1)
+  }
+}
+
+function extractCommand(args: string[]): {
+  command: CliCommand
+  optionArgs: string[]
+} {
+  const possibleCommand =
+    args[0] && !args[0].startsWith("--") ? (args[0] as CliCommand) : undefined
+  const command = possibleCommand ?? "build"
+  const optionArgs = possibleCommand ? args.slice(1) : args
+  return { command, optionArgs }
+}
+
+function parseOptions(args: string[]): CliOptions {
+  const options: CliOptions = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === undefined) {
+      continue
+    }
+    if (!arg.startsWith("--")) {
+      logWarn(`Ignoring unexpected argument: ${arg}`)
+      continue
+    }
+    const next = args[index + 1]
+    switch (arg) {
+      case "--workspace":
+        if (!next || next.startsWith("--")) {
+          throw new Error("--workspace flag requires a path argument")
+        }
+        options.workspaceRoot = path.resolve(process.cwd(), next)
+        index += 1
+        break
+      case "--artifacts":
+        if (!next || next.startsWith("--")) {
+          throw new Error("--artifacts flag requires a path argument")
+        }
+        options.artifactsRoot = path.resolve(process.cwd(), next)
+        index += 1
+        break
+      case "--dry-run":
+        options.dryRun = true
+        break
+      case "--skip-publish":
+        options.skipPublish = true
+        break
+      default:
+        logWarn(`Unknown flag: ${arg}`)
+    }
+  }
+  return options
+}
+
+function printPlan(groups: BuildGroup[]): void {
+  separator()
+  logTask("tscircuit bleeding build plan")
+  groups.forEach((group, groupIndex) => {
+    logInfo(`${groupIndex + 1}. ${group.name}`)
+    group.packages.forEach((pkg) => {
+      logInfo(`    • ${pkg.name} ← ${pkg.repository.url}`)
+    })
+  })
+  separator()
+}
+
+async function cleanWorkspace(options: CliOptions): Promise<void> {
+  const workspaceRoot =
+    options.workspaceRoot ?? path.join(process.cwd(), DEFAULT_WORKSPACE_DIR)
+  if (!(await pathExists(workspaceRoot))) {
+    logInfo(`No workspace found at ${workspaceRoot}`)
+    return
+  }
+  await removeDir(workspaceRoot)
+  logSuccess(`Removed workspace at ${workspaceRoot}`)
+}
+
+async function runBuild(options: CliOptions): Promise<void> {
+  if (options.dryRun) {
+    logWarn("Running build in dry-run mode. No commands will be executed.")
+  }
+  await runBuildSystem(BUILD_GROUPS, options)
+}
+
+await main().catch((error) => {
+  logError(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})
+
+export {}

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "build": "bun run index.ts build",
+    "plan": "bun run index.ts plan",
+    "clean": "bun run index.ts clean",
+    "typecheck": "bunx tsc --noEmit",
     "format": "biome format --write ."
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/node": "^20.12.7"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/build-system.ts
+++ b/src/build-system.ts
@@ -1,0 +1,352 @@
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { ensureDir, moveFile } from "./fs-utils"
+import { logInfo, logSuccess, logTask, logWarn, separator } from "./logger"
+import { readPackageJson } from "./package-json"
+import { checkoutRepository, type CheckoutContext } from "./repo"
+import { runCommand } from "./run-command"
+import type {
+  BuildGroup,
+  BuildGroupResult,
+  BuildReport,
+  BuildSystemOptions,
+  PackageBuildResult,
+  PackageConfig,
+  PackConfig,
+  RepositoryCheckout,
+} from "./types"
+import { linkLocalDependencies, publishWithYalc } from "./yalc"
+
+interface BuildContext {
+  workspaceRoot: string
+  artifactsRoot: string
+  reposRoot: string
+  options: BuildSystemOptions
+  builtPackages: Map<string, PackageBuildResult>
+  checkoutCache: Map<string, RepositoryCheckout>
+}
+
+export const DEFAULT_WORKSPACE_DIR = ".tscircuit-workspace"
+export const REPOS_DIR_NAME = "repos"
+export const ARTIFACTS_DIR_NAME = "artifacts"
+
+export async function runBuildSystem(
+  groups: BuildGroup[],
+  options: BuildSystemOptions = {},
+): Promise<BuildReport> {
+  const workspaceRoot =
+    options.workspaceRoot ?? path.join(process.cwd(), DEFAULT_WORKSPACE_DIR)
+  const artifactsRoot =
+    options.artifactsRoot ?? path.join(workspaceRoot, ARTIFACTS_DIR_NAME)
+  const reposRoot = path.join(workspaceRoot, REPOS_DIR_NAME)
+
+  await Promise.all([
+    ensureDir(workspaceRoot),
+    ensureDir(artifactsRoot),
+    ensureDir(reposRoot),
+  ])
+
+  logInfo(`Workspace root: ${workspaceRoot}`)
+  logInfo(`Artifacts directory: ${artifactsRoot}`)
+  logInfo(`Repositories cache: ${reposRoot}`)
+
+  const context: BuildContext = {
+    workspaceRoot,
+    artifactsRoot,
+    reposRoot,
+    options,
+    builtPackages: new Map(),
+    checkoutCache: new Map(),
+  }
+
+  const checkoutContext: CheckoutContext = {
+    reposRoot,
+    checkoutCache: context.checkoutCache,
+  }
+
+  const groupResults: BuildGroupResult[] = []
+
+  for (const group of groups) {
+    separator()
+    logTask(`Starting group: ${group.name}`)
+
+    const results = await Promise.all(
+      group.packages.map((pkg) => buildPackage(pkg, context, checkoutContext)),
+    )
+
+    for (const result of results) {
+      context.builtPackages.set(result.packageJson.name, result)
+    }
+
+    groupResults.push({ group, results })
+    logSuccess(`Completed group: ${group.name}`)
+  }
+
+  const report: BuildReport = {
+    generatedAt: new Date().toISOString(),
+    workspaceRoot,
+    artifactsRoot,
+    groups: groupResults,
+  }
+
+  const reportPath = path.join(artifactsRoot, "build-report.json")
+  await writeFile(reportPath, JSON.stringify(report, null, 2), "utf8")
+  logSuccess(`Wrote build report to ${reportPath}`)
+
+  separator()
+  logSuccess("Build pipeline finished successfully.")
+
+  return report
+}
+
+async function buildPackage(
+  pkg: PackageConfig,
+  context: BuildContext,
+  checkoutContext: CheckoutContext,
+): Promise<PackageBuildResult> {
+  logTask(`Building package ${pkg.name}`)
+  const start = performance.now()
+
+  const repository = await checkoutRepository(pkg, checkoutContext)
+  const packageDir = pkg.packageDir
+    ? path.join(repository.dir, pkg.packageDir)
+    : repository.dir
+
+  const packageJson = await readPackageJson(packageDir)
+
+  let linkedDependencies: string[] = []
+  if (context.options.dryRun) {
+    if (context.builtPackages.size > 0) {
+      logWarn(`Skipping yalc linking for ${pkg.name} (dry-run)`)
+    }
+  } else {
+    linkedDependencies = await linkLocalDependencies(
+      packageDir,
+      packageJson,
+      context.builtPackages,
+    )
+  }
+
+  const env = { HUSKY: "0", CI: "1", ...pkg.env } satisfies Record<
+    string,
+    string
+  >
+
+  const durations: PackageBuildResult["durations"] = { totalMs: 0 }
+
+  if (pkg.skipInstall) {
+    logInfo(`Skipping install for ${pkg.name} (package configuration)`)
+  } else if (context.options.dryRun) {
+    logWarn(`Skipping install for ${pkg.name} (dry-run)`)
+  } else {
+    durations.installMs = await runStep(() => runInstall(pkg, packageDir, env))
+  }
+
+  if (pkg.skipBuild) {
+    logInfo(`Skipping build for ${pkg.name} (package configuration)`)
+  } else if (context.options.dryRun) {
+    logWarn(`Skipping build for ${pkg.name} (dry-run)`)
+  } else {
+    durations.buildMs = await runStep(() => runBuild(pkg, packageDir, env))
+  }
+
+  const yalcPublished = await runPublish(pkg, packageDir, env, context.options)
+
+  const packResult = await runPack(pkg, packageDir, packageJson, context, env)
+
+  durations.totalMs = performance.now() - start
+
+  return {
+    config: pkg,
+    packageJson,
+    repository,
+    packageDir,
+    linkedDependencies,
+    yalcPublished,
+    durations,
+    packResult,
+  }
+}
+
+async function runInstall(
+  pkg: PackageConfig,
+  packageDir: string,
+  env: Record<string, string>,
+): Promise<void> {
+  const command = pkg.installCommand ?? ["bun", "install"]
+  if (!command.length) {
+    throw new Error(`Install command for ${pkg.name} is empty`)
+  }
+  logInfo(`Installing dependencies for ${pkg.name}`)
+  await runCommand(command[0]!, command.slice(1), { cwd: packageDir, env })
+}
+
+async function runBuild(
+  pkg: PackageConfig,
+  packageDir: string,
+  env: Record<string, string>,
+): Promise<void> {
+  await executeCommands(
+    pkg.preBuildCommands,
+    packageDir,
+    env,
+    `pre-build for ${pkg.name}`,
+  )
+
+  const command = pkg.buildCommand ?? ["bun", "run", "build"]
+  if (!command.length) {
+    throw new Error(`Build command for ${pkg.name} is empty`)
+  }
+  logInfo(`Running build for ${pkg.name}`)
+  await runCommand(command[0]!, command.slice(1), { cwd: packageDir, env })
+
+  await executeCommands(
+    pkg.postBuildCommands,
+    packageDir,
+    env,
+    `post-build for ${pkg.name}`,
+  )
+}
+
+async function executeCommands(
+  commands: string[][] | undefined,
+  packageDir: string,
+  env: Record<string, string>,
+  label: string,
+): Promise<void> {
+  if (!commands) {
+    return
+  }
+  for (const command of commands) {
+    if (!command.length) {
+      continue
+    }
+    logInfo(`Running ${label} command: ${command.join(" ")}`)
+    await runCommand(command[0]!, command.slice(1), { cwd: packageDir, env })
+  }
+}
+
+async function runPublish(
+  pkg: PackageConfig,
+  packageDir: string,
+  env: Record<string, string>,
+  options: BuildSystemOptions,
+): Promise<boolean> {
+  if (options.skipPublish) {
+    logWarn(`Skipping yalc publish for ${pkg.name} (global skip)`)
+    return false
+  }
+  if (options.dryRun) {
+    logWarn(`Skipping yalc publish for ${pkg.name} (dry-run)`)
+    return false
+  }
+  return publishWithYalc(packageDir, pkg, { env, skip: options.skipPublish })
+}
+
+async function runPack(
+  pkg: PackageConfig,
+  packageDir: string,
+  packageJson: { name: string; version?: string },
+  context: BuildContext,
+  env: Record<string, string>,
+): Promise<PackageBuildResult["packResult"]> {
+  if (!pkg.pack) {
+    return undefined
+  }
+  if (context.options.dryRun) {
+    logWarn(`Skipping pack step for ${pkg.name} (dry-run)`)
+    return undefined
+  }
+
+  const command = pkg.pack.command
+  if (!command.length) {
+    throw new Error(`Pack command for ${pkg.name} is empty`)
+  }
+
+  logInfo(`Packaging ${pkg.name}`)
+  const { stdout } = await runCommand(command[0]!, command.slice(1), {
+    cwd: packageDir,
+    stdout: "pipe",
+    env,
+  })
+  const outputLines =
+    stdout
+      ?.split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean) ?? []
+  if (!outputLines.length) {
+    throw new Error(`Pack command for ${pkg.name} did not produce any output`)
+  }
+  const artifactLine = findPackArtifactLine(outputLines)
+  if (!artifactLine) {
+    throw new Error(
+      `Unable to locate artifact path in pack output for ${pkg.name}`,
+    )
+  }
+  const artifactSource = resolvePackSource(artifactLine, packageDir)
+  const destinationDir = pkg.pack.destinationDir ?? context.artifactsRoot
+  await ensureDir(destinationDir)
+  const destinationName = resolveArtifactName(
+    pkg.pack,
+    packageJson,
+    artifactSource,
+  )
+  const destinationPath = path.join(destinationDir, destinationName)
+
+  await moveFile(artifactSource, destinationPath)
+  logSuccess(`Created artifact for ${pkg.name}: ${destinationPath}`)
+
+  return {
+    artifactPath: destinationPath,
+    originalPath: artifactSource,
+    command,
+  }
+}
+
+function findPackArtifactLine(lines: string[]): string | undefined {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]
+    if (!line) {
+      continue
+    }
+    if (/\.(?:tgz|tar\.gz)$/i.test(line)) {
+      return line
+    }
+  }
+  return lines.at(-1)
+}
+
+function resolvePackSource(outputLine: string, packageDir: string): string {
+  if (path.isAbsolute(outputLine)) {
+    return outputLine
+  }
+  return path.join(packageDir, outputLine)
+}
+
+function resolveArtifactName(
+  pack: PackConfig,
+  packageJson: { name: string; version?: string },
+  source: string,
+): string {
+  if (pack.artifactName) {
+    return pack.artifactName
+      .replace(/%name%/g, sanitizeForFile(packageJson.name))
+      .replace(/%version%/g, packageJson.version ?? "0.0.0")
+      .replace(/%timestamp%/g, createTimestamp())
+  }
+  return path.basename(source)
+}
+
+function sanitizeForFile(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-")
+}
+
+function createTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-")
+}
+
+async function runStep(step: () => Promise<unknown>): Promise<number> {
+  const start = performance.now()
+  await step()
+  return performance.now() - start
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,151 @@
+import type { BuildGroup, PackageConfig, RepositoryConfig } from "./types"
+
+function githubRepository(
+  repo: string,
+  options: { branch?: string; checkoutDir?: string } = {},
+): RepositoryConfig {
+  return {
+    url: `https://github.com/${repo}.git`,
+    branch: options.branch,
+    checkoutDir: options.checkoutDir,
+  }
+}
+
+function packageFromGithub(config: {
+  name: string
+  repo: string
+  checkoutDir: string
+  packageDir?: string
+  installCommand?: string[]
+  buildCommand?: string[]
+  publishCommand?: string[]
+  skipInstall?: boolean
+  skipBuild?: boolean
+  skipPublish?: boolean
+  pack?: PackageConfig["pack"]
+  env?: Record<string, string>
+  preBuildCommands?: string[][]
+  postBuildCommands?: string[][]
+  branch?: string
+}): PackageConfig {
+  const {
+    name,
+    repo,
+    checkoutDir,
+    packageDir,
+    installCommand,
+    buildCommand,
+    publishCommand,
+    skipInstall,
+    skipBuild,
+    skipPublish,
+    pack,
+    env,
+    preBuildCommands,
+    postBuildCommands,
+    branch,
+  } = config
+
+  return {
+    name,
+    repository: githubRepository(repo, { checkoutDir, branch }),
+    packageDir,
+    installCommand,
+    buildCommand,
+    publishCommand,
+    skipInstall,
+    skipBuild,
+    skipPublish,
+    pack,
+    env,
+    preBuildCommands,
+    postBuildCommands,
+  } satisfies PackageConfig
+}
+
+export const BUILD_GROUPS: BuildGroup[] = [
+  {
+    name: "Group 1",
+    packages: [
+      packageFromGithub({
+        name: "circuit-json",
+        repo: "tscircuit/circuit-json",
+        checkoutDir: "circuit-json",
+      }),
+    ],
+  },
+  {
+    name: "Group 2",
+    packages: [
+      packageFromGithub({
+        name: "@tscircuit/props",
+        repo: "tscircuit/props",
+        checkoutDir: "tscircuit-props",
+      }),
+    ],
+  },
+  {
+    name: "Group 3",
+    packages: [
+      packageFromGithub({
+        name: "@tscircuit/core",
+        repo: "tscircuit/core",
+        checkoutDir: "tscircuit-core",
+      }),
+      packageFromGithub({
+        name: "@tscircuit/pcb-viewer",
+        repo: "tscircuit/pcb-viewer",
+        checkoutDir: "tscircuit-pcb-viewer",
+      }),
+      packageFromGithub({
+        name: "@tscircuit/schematic-viewer",
+        repo: "tscircuit/schematic-viewer",
+        checkoutDir: "tscircuit-schematic-viewer",
+      }),
+      packageFromGithub({
+        name: "@tscircuit/3d-viewer",
+        repo: "tscircuit/3d-viewer",
+        checkoutDir: "tscircuit-3d-viewer",
+      }),
+    ],
+  },
+  {
+    name: "Group 4",
+    packages: [
+      packageFromGithub({
+        name: "@tscircuit/eval",
+        repo: "tscircuit/eval",
+        checkoutDir: "tscircuit-eval",
+      }),
+      packageFromGithub({
+        name: "@tscircuit/runframe",
+        repo: "tscircuit/runframe",
+        checkoutDir: "tscircuit-runframe",
+      }),
+    ],
+  },
+  {
+    name: "Group 5",
+    packages: [
+      packageFromGithub({
+        name: "@tscircuit/cli",
+        repo: "tscircuit/cli",
+        checkoutDir: "tscircuit-cli",
+      }),
+    ],
+  },
+  {
+    name: "Group 6",
+    packages: [
+      packageFromGithub({
+        name: "tscircuit",
+        repo: "tscircuit/tscircuit",
+        checkoutDir: "tscircuit",
+        pack: {
+          command: ["npm", "pack"],
+          artifactName: "tscircuit-bleeding-%timestamp%.tgz",
+        },
+      }),
+    ],
+  },
+]

--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -1,0 +1,49 @@
+import { access, copyFile, mkdir, readFile, rename, rm } from "node:fs/promises"
+import path from "node:path"
+
+export async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true })
+}
+
+export async function removeDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true })
+}
+
+export async function moveFile(
+  source: string,
+  destination: string,
+): Promise<void> {
+  try {
+    await rename(source, destination)
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code === "EXDEV") {
+      await ensureDir(path.dirname(destination))
+      await copyFile(source, destination)
+      await rm(source, { force: true })
+    } else {
+      throw error
+    }
+  }
+}
+
+export async function readJsonFile<T>(filePath: string): Promise<T> {
+  const contents = await readFile(filePath, "utf8")
+  return JSON.parse(contents) as T
+}
+
+export function resolveWorkspacePath(
+  root: string,
+  ...segments: string[]
+): string {
+  return path.join(root, ...segments)
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,55 @@
+const enum Color {
+  Reset = "\x1b[0m",
+  Cyan = "\x1b[36m",
+  Yellow = "\x1b[33m",
+  Red = "\x1b[31m",
+  Green = "\x1b[32m",
+  Magenta = "\x1b[35m",
+  Gray = "\x1b[90m",
+}
+
+const SYMBOLS = {
+  info: "ℹ",
+  warn: "⚠",
+  error: "✖",
+  success: "✔",
+  task: "➤",
+}
+
+function colorize(color: Color, message: string): string {
+  return `${color}${message}${Color.Reset}`
+}
+
+export function logInfo(message: string): void {
+  console.log(`${colorize(Color.Cyan, SYMBOLS.info)} ${message}`)
+}
+
+export function logWarn(message: string): void {
+  console.warn(`${colorize(Color.Yellow, SYMBOLS.warn)} ${message}`)
+}
+
+export function logError(message: string): void {
+  console.error(`${colorize(Color.Red, SYMBOLS.error)} ${message}`)
+}
+
+export function logSuccess(message: string): void {
+  console.log(`${colorize(Color.Green, SYMBOLS.success)} ${message}`)
+}
+
+export function logTask(message: string): void {
+  console.log(`${colorize(Color.Magenta, SYMBOLS.task)} ${message}`)
+}
+
+export function logCommand(cwd: string | undefined, command: string[]): void {
+  const location = cwd
+    ? colorize(Color.Gray, `[${cwd}]`)
+    : colorize(Color.Gray, `[.]`)
+  const rendered = command
+    .map((part) => (part.includes(" ") ? `"${part}"` : part))
+    .join(" ")
+  console.log(`${location} $ ${rendered}`)
+}
+
+export function separator(): void {
+  console.log(colorize(Color.Gray, "----------------------------------------"))
+}

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -1,0 +1,10 @@
+import path from "node:path"
+import { readJsonFile } from "./fs-utils"
+import type { PackageJson } from "./types"
+
+export async function readPackageJson(
+  packageDir: string,
+): Promise<PackageJson> {
+  const packageJsonPath = path.join(packageDir, "package.json")
+  return readJsonFile<PackageJson>(packageJsonPath)
+}

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,0 +1,76 @@
+import path from "node:path"
+import { ensureDir, pathExists } from "./fs-utils"
+import { logInfo } from "./logger"
+import { runCommand } from "./run-command"
+import type { PackageConfig, RepositoryCheckout } from "./types"
+
+export interface CheckoutContext {
+  reposRoot: string
+  checkoutCache: Map<string, RepositoryCheckout>
+}
+
+export async function checkoutRepository(
+  pkg: PackageConfig,
+  context: CheckoutContext,
+): Promise<RepositoryCheckout> {
+  const branch = pkg.repository.branch ?? "main"
+  const checkoutKey = pkg.checkoutKey ?? `${pkg.repository.url}#${branch}`
+
+  const existing = context.checkoutCache.get(checkoutKey)
+  if (existing) {
+    return existing
+  }
+
+  await ensureDir(context.reposRoot)
+
+  const checkoutDirName =
+    pkg.repository.checkoutDir ?? slugifyRepositoryUrl(pkg.repository.url)
+  const repoDir = path.join(context.reposRoot, checkoutDirName)
+
+  if (!(await pathExists(repoDir))) {
+    logInfo(`Cloning ${pkg.repository.url} into ${repoDir}`)
+    const cloneArgs = [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      pkg.repository.url,
+      repoDir,
+    ]
+    await runCommand("git", cloneArgs)
+  } else {
+    logInfo(`Updating ${repoDir}`)
+    await runCommand("git", ["fetch"], { cwd: repoDir })
+    await runCommand("git", ["checkout", branch], { cwd: repoDir })
+    await runCommand("git", ["reset", "--hard", `origin/${branch}`], {
+      cwd: repoDir,
+    })
+    await runCommand("git", ["clean", "-fdx"], { cwd: repoDir })
+  }
+
+  const revisionResult = await runCommand("git", ["rev-parse", "HEAD"], {
+    cwd: repoDir,
+    stdout: "pipe",
+  })
+  const commit = revisionResult.stdout?.trim() ?? ""
+
+  const checkout: RepositoryCheckout = {
+    url: pkg.repository.url,
+    dir: repoDir,
+    branch,
+    commit,
+  }
+
+  context.checkoutCache.set(checkoutKey, checkout)
+  return checkout
+}
+
+function slugifyRepositoryUrl(repoUrl: string): string {
+  let normalized = repoUrl.replace(/\.git$/, "")
+  if (normalized.includes("@")) {
+    normalized = normalized.replace(/^git@/, "").replace(/:/, "/")
+  }
+  normalized = normalized.replace(/^https?:\/\//, "")
+  return normalized.replace(/[^a-zA-Z0-9]+/g, "-")
+}

--- a/src/run-command.ts
+++ b/src/run-command.ts
@@ -1,0 +1,64 @@
+import { logCommand } from "./logger"
+
+export interface RunCommandOptions {
+  cwd?: string
+  env?: Record<string, string>
+  stdout?: "inherit" | "pipe" | "ignore"
+  stderr?: "inherit" | "pipe" | "ignore"
+  allowFailure?: boolean
+}
+
+export interface RunCommandResult {
+  exitCode: number
+  stdout?: string
+  stderr?: string
+}
+
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: RunCommandOptions = {},
+): Promise<RunCommandResult> {
+  const { cwd, env, stdout, stderr, allowFailure } = options
+  const finalEnv = { ...process.env, ...env }
+  const commandParts = [command, ...args]
+  logCommand(cwd, commandParts)
+
+  const stdoutMode = stdout ?? "inherit"
+  const stderrMode = stderr ?? "inherit"
+
+  const subprocess = Bun.spawn({
+    cmd: commandParts,
+    cwd,
+    env: finalEnv,
+    stdin: "inherit",
+    stdout: stdoutMode,
+    stderr: stderrMode,
+  })
+
+  const stdoutPromise =
+    stdoutMode === "pipe"
+      ? new Response(subprocess.stdout!).text()
+      : Promise.resolve<string | undefined>(undefined)
+  const stderrPromise =
+    stderrMode === "pipe"
+      ? new Response(subprocess.stderr!).text()
+      : Promise.resolve<string | undefined>(undefined)
+
+  const exitCode = await subprocess.exited
+  const [collectedStdout, collectedStderr] = await Promise.all([
+    stdoutPromise,
+    stderrPromise,
+  ])
+
+  if (exitCode !== 0 && !allowFailure) {
+    const error = new Error(
+      `Command failed with exit code ${exitCode}: ${commandParts.join(" ")}`,
+    )
+    ;(error as Error & Partial<RunCommandResult>).stdout = collectedStdout
+    ;(error as Error & Partial<RunCommandResult>).stderr = collectedStderr
+    throw error
+  }
+
+  return { exitCode, stdout: collectedStdout, stderr: collectedStderr }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,115 @@
+export interface RepositoryConfig {
+  /** Full git url (https://, git@, etc.) */
+  url: string
+  /** Branch to checkout, defaults to "main" */
+  branch?: string
+  /**
+   * Directory name under the repos workspace. When multiple packages live in the
+   * same git repository, provide the same checkoutDir for each to avoid
+   * duplicate clones.
+   */
+  checkoutDir?: string
+}
+
+export interface PackConfig {
+  /** Command to run that produces a tarball for the package. */
+  command: string[]
+  /** Optional directory for the final artifact (defaults to workspace artifacts folder). */
+  destinationDir?: string
+  /** Optional explicit artifact name override. */
+  artifactName?: string
+}
+
+export interface PackageConfig {
+  /** npm package name */
+  name: string
+  /** Git repository configuration */
+  repository: RepositoryConfig
+  /** Relative directory that contains the package (defaults to repo root) */
+  packageDir?: string
+  /** Optional key to reuse repository checkout across packages */
+  checkoutKey?: string
+  /** Command used to install dependencies (defaults to ["bun", "install"]) */
+  installCommand?: string[]
+  /** Command used to build the project (defaults to ["bun", "run", "build"]) */
+  buildCommand?: string[]
+  /** Command used to publish the package to yalc (defaults to ["bunx", "yalc", "publish"]) */
+  publishCommand?: string[]
+  /** Optional packaging command (e.g. npm pack) */
+  pack?: PackConfig
+  /** Skip installation step */
+  skipInstall?: boolean
+  /** Skip build step */
+  skipBuild?: boolean
+  /** Skip yalc publish */
+  skipPublish?: boolean
+  /** Extra environment variables applied to commands */
+  env?: Record<string, string>
+  /** Commands executed before the main build command */
+  preBuildCommands?: string[][]
+  /** Commands executed after the main build command */
+  postBuildCommands?: string[][]
+}
+
+export interface BuildGroup {
+  name: string
+  packages: PackageConfig[]
+}
+
+export interface PackageJson {
+  name: string
+  version?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  [key: string]: unknown
+}
+
+export interface RepositoryCheckout {
+  url: string
+  dir: string
+  branch: string
+  commit: string
+}
+
+export interface PackResult {
+  artifactPath: string
+  originalPath: string
+  command: string[]
+}
+
+export interface PackageBuildResult {
+  config: PackageConfig
+  packageJson: PackageJson
+  repository: RepositoryCheckout
+  packageDir: string
+  linkedDependencies: string[]
+  yalcPublished: boolean
+  durations: {
+    installMs?: number
+    buildMs?: number
+    publishMs?: number
+    totalMs: number
+  }
+  packResult?: PackResult
+}
+
+export interface BuildGroupResult {
+  group: BuildGroup
+  results: PackageBuildResult[]
+}
+
+export interface BuildReport {
+  generatedAt: string
+  workspaceRoot: string
+  artifactsRoot: string
+  groups: BuildGroupResult[]
+}
+
+export interface BuildSystemOptions {
+  workspaceRoot?: string
+  artifactsRoot?: string
+  dryRun?: boolean
+  skipPublish?: boolean
+}

--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -1,0 +1,54 @@
+import { logInfo, logWarn } from "./logger"
+import { runCommand } from "./run-command"
+import type { PackageBuildResult, PackageConfig, PackageJson } from "./types"
+
+export async function linkLocalDependencies(
+  packageDir: string,
+  packageJson: PackageJson,
+  builtPackages: Map<string, PackageBuildResult>,
+): Promise<string[]> {
+  const dependencyMaps = [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.peerDependencies,
+    packageJson.optionalDependencies,
+  ]
+
+  const required = new Set<string>()
+  for (const [name] of builtPackages) {
+    if (dependencyMaps.some((deps) => deps && name in deps)) {
+      required.add(name)
+    }
+  }
+
+  const linked: string[] = []
+  for (const name of required) {
+    logInfo(`Linking local dependency ${name} with yalc`)
+    await runCommand("bunx", ["yalc", "add", name], { cwd: packageDir })
+    linked.push(name)
+  }
+
+  return linked
+}
+
+export async function publishWithYalc(
+  packageDir: string,
+  pkg: PackageConfig,
+  options: { env?: Record<string, string>; skip?: boolean } = {},
+): Promise<boolean> {
+  if (pkg.skipPublish) {
+    logWarn(`Skipping yalc publish for ${pkg.name} (package configuration)`)
+    return false
+  }
+  if (options.skip) {
+    logWarn(`Skipping yalc publish for ${pkg.name} (explicit skip)`)
+    return false
+  }
+  const command = pkg.publishCommand ?? ["bunx", "yalc", "publish"]
+  logInfo(`Publishing ${pkg.name} to local yalc store`)
+  await runCommand(command[0]!, command.slice(1), {
+    cwd: packageDir,
+    env: options.env,
+  })
+  return true
+}


### PR DESCRIPTION
## Summary
- add a Bun-powered CLI entrypoint for orchestrating the bleeding build workflow
- implement reusable build utilities for cloning repositories, linking yalc packages, publishing, and packaging artifacts
- codify the group build order and metadata for tscircuit dependencies while expanding project scripts and ignores

## Testing
- bunx tsc --noEmit
- bun run plan
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68c8f3425370832e83a5463f8bd78359